### PR TITLE
fix sample code for using Transliteration and module's __init__.py

### DIFF
--- a/transliteration/__init__.py
+++ b/transliteration/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from core import Transliterator, getInstance
+from transliteration.core import Transliterator, getInstance
 
 


### PR DESCRIPTION
1. there was no method 'get_instance', made sample code more pythonic
2. target language code was used wrong ("ml" instead of "ml_IN")
3. changed import structure for ./transliteration/**init**.py (there was no module 'transliteration' inside)
