### PR TITLE
Corrected the transliteration for English to Hindi

### DIFF
--- a/tests/transliterationtest.py
+++ b/tests/transliterationtest.py
@@ -37,7 +37,7 @@ class TransliterationTest(unittest.TestCase):
         result = self.t.transliterate(self.en, "hi_IN")
         print result.encode('utf-8')
         self.assertEqual(result.strip(),
-                         u"दिस इज़  इन्गलिष टैक्स्ट फौर transliteration")
+                         u"दिस इज़ अ इन्गलिष टैक्स्ट फौर transliteration")
 
     def testHindiToEnglish(self):
         result = self.t.transliterate(self.hi, "en_US")

--- a/transliteration/cmudict.py
+++ b/transliteration/cmudict.py
@@ -79,7 +79,7 @@ class CMUDict():
                     pronunciation_str += CMU_HINDI_MAP[symbol]
                 except KeyError:
                     pronunciation_str += symbol
-                pronunciation_str = self._fix_vowel_signs_hi(pronunciation_str)
+            pronunciation_str = self._fix_vowel_signs_hi(pronunciation_str)
         return (pronunciation_str).decode("utf-8") + punctuations
 
     def _fix_vowel_signs_ml(self, text):
@@ -130,16 +130,23 @@ class CMUDict():
         return text
 
     def _fix_vowel_signs_hi(self, text):
-        text = text.replace("अ", "")
-        text = text.replace("आ", "ा")
-        text = text.replace("इ", "ि")
-        text = text.replace("ई", "ी")
-        text = text.replace("उ", "ु")
-        text = text.replace("ऊ", "ू")
-        text = text.replace("ऋ", "ृ")
-        text = text.replace("ए", "े")
-        text = text.replace("ऐ", "ै")
-        text = text.replace("ओ", "ो")
-        text = text.replace("औ", "ौ")
-        text = text.replace("ङ", "न्")
-        return text
+        swar = ["अ", "आ", "इ", "ई", "उ", "ऊ", "ऋ", "ए", "ऐ", "ओ", "औ"]
+        swar_dict = {
+            "अ": "", "आ": "ा", "इ": "ि", "ई": "ी", "उ": "ु", "ऊ": "ू",
+            "ऋ": "ृ", "ए": "े", "ऐ": "ै", "ओ": "ो", "औ": "ौ", "ङ": "न्"
+        }
+
+        return_text = ""
+
+        text = list(text.decode("utf-8"))
+
+        for i in range(len(text)):
+            sub_text = text[i].encode("utf-8")
+            if i > 0 and sub_text in swar and text[i-1].encode("utf-8") not in swar:
+                return_text += swar_dict[sub_text]
+            elif sub_text == "ङ" and i != (len(text)-1):
+                return_text += swar_dict[sub_text]
+            else:
+                return_text += sub_text
+
+        return return_text


### PR DESCRIPTION
When a text is converted to Hindi, not all vowel's form should be changed. For example, before this commit, "is" was translated as िज़ and "easy" was translated to ीज़ी both of which are wrong. The correct way to write them are, इज़  and ईज़ी respectively. This commit takes care of that. 